### PR TITLE
fix: fix typo in actor knownFollowers method name

### DIFF
--- a/packages/core/src/actor.ts
+++ b/packages/core/src/actor.ts
@@ -219,7 +219,7 @@ export class User extends BaseActor {
   /**
    * Enumerates accounts which follow a specified account (actor) and are followed by the viewer.
    */
-  knowFollowers(
+  knownFollowers(
     params: { actor: string; limit?: number },
     options?: AppBskyGraphGetKnownFollowers.CallOptions,
   ) {


### PR DESCRIPTION
Fixes a small typo where `knownFollowers` was `knowFollowers`