### PR TITLE
chore: setup chat.tsky.dev

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -33,7 +33,7 @@ export default defineConfig({
 
     socialLinks: [
       { icon: 'github', link: 'https://github.com/tsky-dev/tsky' },
-      { icon: 'discord', link: 'https://discord.gg/f7XWweBJQP' },
+      { icon: 'discord', link: 'https://chat.tsky.dev' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/tsky.dev' },
     ],
 

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -13,6 +13,6 @@ force = true
 # Redirect to Discord server
 [[redirects]]
 from = "https://chat.tsky.dev"
-to = "https://discord.gg/f7XWweBJQP"
+to = "https://discord.com/invite/PRv6QhWu"
 status = 301
 force = true

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -9,3 +9,10 @@ from = "/docs/*"
 to = "/:splat"
 status = 200
 force = true
+
+# Redirect to Discord server
+[[redirects]]
+from = "https://chat.tsky.dev"
+to = "https://discord.gg/f7XWweBJQP"
+status = 301
+force = true

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -13,6 +13,6 @@ force = true
 # Redirect to Discord server
 [[redirects]]
 from = "https://chat.tsky.dev"
-to = "https://discord.com/invite/PRv6QhWu"
+to = "https://discord.gg/KPD7XPUZn3"
 status = 301
 force = true


### PR DESCRIPTION
Redirect from https://chat.tsky.dev to https://discord.gg/f7XWweBJQP

I don't know if we can have an invite that goes to the #tsky channel when joining. Folks should be able to find their way there though.
