### PR TITLE
chore: set casing for tsky, Tsky, Bluesky

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
   <img src=".github/assets/tsky-logo.png" width="200" height="200">
 </p>
 
-<h1 align="center">TSky</h1>
+<h1 align="center">tsky</h1>
 
 <p align="center">
   A lightweight, fast, universal and typed Bluesky API wrapper for Apps & Bots.
 </p>
 
-## ⚠️ TSky is still in development and is not ready for production use.
+## ⚠️ tsky is still in development and is not ready for production use.
 
-TSksy is still in active development and is not ready for production use. If you want to contribute to the project, please read the [CONTRIBUTING.md](CONTRIBUTING.md) file or join our [Discord Server](https://discord.gg/KPD7XPUZn3).
+tsky is still in active development and is not ready for production use. If you want to contribute to the project, please read the [CONTRIBUTING.md](CONTRIBUTING.md) file or join our [Discord Server](https://discord.gg/KPD7XPUZn3).
 
-TSky is a lightweight, fast, universal and typed Bluesky API wrapper for Apps & Bots. It's designed to be easy to use, lightweight and straightforward to use. It's built with TypeScript and has full type support.
+tsky is a lightweight, fast, universal and typed Bluesky API wrapper for Apps & Bots. It's designed to be easy to use, lightweight and straightforward to use. It's built with TypeScript and has full type support.
 
 It was primarily built for the [Nimbus Client](https://github.com/nimbus-town/nimbus) but can be used in any other project that requires Bluesky API integration.
 
@@ -48,9 +48,9 @@ console.log(profile.handle);
 
 ## Links
 
-- [📚 TSky Documentation](https://tsky.dev/)
-- [🦋 TSky on Bluesky](https://bsky.app/profile/tsky.dev)
-- [📣 TSky Discord Server](https://discord.gg/KPD7XPUZn3)
+- [📚 tsky Documentation](https://tsky.dev/)
+- [🦋 tsky on Bluesky](https://bsky.app/profile/tsky.dev)
+- [📣 tsky Discord Server](https://discord.gg/KPD7XPUZn3)
 - [🦋 Nimbus on Bluesky](https://bsky.app/profile/nimbus.town)
 
 ## Contributing

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,8 +2,8 @@ import { defineConfig } from 'vitepress';
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
-  title: 'TSky',
-  description: 'A BlueSky API client for nimble apps and tools',
+  title: 'tsky',
+  description: 'A Bluesky API client for nimble apps and tools',
   themeConfig: {
     nav: [
       { text: 'Home', link: '/' },

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@
 layout: home
 
 hero:
-  name: "TSky"
-  text: "A BlueSky API client for nimble apps and tools"
-  tagline: A BlueSky API client for nimble apps and tools
+  name: "tsky"
+  text: "A Bluesky API client for nimble apps and tools"
+  tagline: A Bluesky API client for nimble apps and tools
   actions:
     - theme: brand
       text: Get Started

--- a/packages/core/src/tsky/tsky.ts
+++ b/packages/core/src/tsky/tsky.ts
@@ -8,7 +8,7 @@ import type {
 } from '@atproto/api';
 import { Paginator } from './paginator';
 
-export class TSky {
+export class Tsky {
   constructor(private instance: AppBskyNS) {}
 
   /**


### PR DESCRIPTION
We're currently using TSky to refer to the library. I think we should switch to tsky, to align with the way bsky is used in Bluesky (there is also now a library called rsky).

For the types, I think we should go with `Tsky`, aligning with the `Bsky` naming convention used in atproto.

This PR also corrects BlueSky to Bluesky.