### PR TITLE
refactor: migrate to scoped package structure (@tsky/*)

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tsky-docs",
+  "name": "@tsky/docs",
   "version": "1.0.0",
   "private": true,
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "tsky-workspace",
+  "name": "tsky",
   "type": "module",
   "version": "0.1.0",
+  "private": true,
   "packageManager": "pnpm@9.14.2",
   "license": "MIT",
   "homepage": "https://tsky.dev/",
@@ -11,9 +12,9 @@
   },
   "scripts": {
     "build": "pnpm run --filter tsky build",
-    "docs:dev": "pnpm run --filter tsky-docs dev",
-    "docs:build": "pnpm run --filter tsky-docs build",
-    "docs:preview": "pnpm run --filter tsky-docs preview",
+    "docs:dev": "pnpm run --filter @tsky/docs dev",
+    "docs:build": "pnpm run --filter @tsky/docs build",
+    "docs:preview": "pnpm run --filter @tsky/docs preview",
     "format": "biome check --write .",
     "format:check": "biome check",
     "lint": "eslint ./packages ./docs",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/tsky-dev/tsky.git"
   },
   "scripts": {
-    "build": "pnpm run --filter tsky build",
+    "build": "pnpm run --filter @tsky/core build",
     "docs:dev": "pnpm run --filter @tsky/docs dev",
     "docs:build": "pnpm run --filter @tsky/docs build",
     "docs:preview": "pnpm run --filter @tsky/docs preview",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,11 @@
 {
-  "name": "tsky",
+  "name": "@tsky/core",
   "type": "module",
   "version": "0.0.1",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
- Rename root package from `tsky-workspace` to `tsky`
- Create `@tsky/core` package (previously `tsky`)
- Rename docs package from `tsky-docs` to `@tsky/docs`
- Update workspace package filters from `--filter tsky-docs` to `--filter @tsky/docs`