### PR TITLE
ci: add `pull-requests: write` permission to allow creating PR from GitHub Actions

### DIFF
--- a/.github/workflows/update-lexicons.yml
+++ b/.github/workflows/update-lexicons.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This should fix a permission issue.

Tested on forked repository:
- Actions run: https://github.com/shuuji3/tsky/actions/runs/12823924560/job/35759210058
- Created PR: https://github.com/shuuji3/tsky/pull/8
