### PR TITLE
chore(client): remove unused function `formatSecret()`

### DIFF
--- a/packages/client/src/bsky/index.test.ts
+++ b/packages/client/src/bsky/index.test.ts
@@ -2,14 +2,6 @@ import { CredentialManager } from '@atcute/client';
 import { describe, expect, it } from 'vitest';
 import { Tsky } from '~/index';
 
-const formatSecret = (secret: string | undefined) => {
-  if (!secret) {
-    throw new Error('Secret is required');
-  }
-
-  return secret.replace(/^tsky /g, '').trim();
-};
-
 const TEST_CREDENTIALS = {
   alice: {
     handle: 'alice.tsky.dev',


### PR DESCRIPTION
follow up for #32

This is just removing an unused function to fix a typecheck error.

```
TS6133: formatSecret is declared but its value is never read.
```