### PR TITLE
ci: run `update-lexicons.yml` every hour

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/update-lexicons.yml
+++ b/.github/workflows/update-lexicons.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/update-lexicons.yml
+++ b/.github/workflows/update-lexicons.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 * * * *'
   workflow_dispatch: {}
   merge_group: {}
 


### PR DESCRIPTION
This ensures running `update-lexicons.yml` workflow to check the latest upstream change hourly even if there's no new commit.