### PR TITLE
ci: reduce frequency of update-lexicons workflow once a day

### DIFF
--- a/.github/workflows/update-lexicons.yml
+++ b/.github/workflows/update-lexicons.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 3 * * *'
   workflow_dispatch: {}
   merge_group: {}
 


### PR DESCRIPTION
ref. #67 

It looks like the Bluesky team updates the lexicon with a couple of PRs in a short period, so this would also help combine them into one PR here.