### PR TITLE
fix(lexicons): support `tid` and `record-key` format in object property

### DIFF
--- a/packages/lex-cli/src/generator/resolvers/string.ts
+++ b/packages/lex-cli/src/generator/resolvers/string.ts
@@ -1,11 +1,13 @@
-import type { StringSchema } from '../schema.js';
 import { IGNORED_FORMATS, TYPE_FORMATS, sortName } from '../../utils/index.js';
+import type { StringSchema } from '../schema.js';
 
 export function resolveStringFormat(format: string, nsid: string): string {
   if (format === 'did') return TYPE_FORMATS.DID;
   if (format === 'cid') return TYPE_FORMATS.CID;
   if (format === 'handle') return TYPE_FORMATS.HANDLE;
   if (format === 'at-uri') return TYPE_FORMATS.URI;
+  if (format === 'tid') return TYPE_FORMATS.TID;
+  if (format === 'record-key') return TYPE_FORMATS.RKEY;
   if (IGNORED_FORMATS.has(format)) return 'string';
 
   console.warn(`${nsid}: unknown format ${format}`);

--- a/packages/lex-cli/src/generator/schema.ts
+++ b/packages/lex-cli/src/generator/schema.ts
@@ -94,7 +94,11 @@ export const stringSchema: t.StrictValidator<
     maxGraphemes?: number;
     minGraphemes?: number;
   } => {
-    if (value.format !== undefined && value.format !== 'uri') {
+    if (
+      value.format !== undefined &&
+      value.format !== 'uri' &&
+      value.format !== 'record-key'
+    ) {
       if (
         value.maxLength !== undefined ||
         value.minLength !== undefined ||

--- a/packages/lex-cli/src/utils/formats.ts
+++ b/packages/lex-cli/src/utils/formats.ts
@@ -3,6 +3,8 @@ export const TYPE_FORMATS = {
   CID: 'At.CID',
   HANDLE: 'At.Handle',
   URI: 'At.Uri',
+  TID: 'At.TID',
+  RKEY: 'At.RKEY',
 } as const;
 
 export const IGNORED_FORMATS = new Set([

--- a/packages/lex-cli/src/utils/prelude.ts
+++ b/packages/lex-cli/src/utils/prelude.ts
@@ -33,7 +33,13 @@ export declare namespace At {
   type Handle = string;
 
   /** URI string */
-  type Uri = string;
+  type Uri = string;       
+
+  /** TID string */
+  type TID = string;
+
+  /** RKEY string */
+  type RKEY = string;
 
   /** Object containing a CID string */
   interface CIDLink {

--- a/packages/lexicons/scripts/tsconfig.json
+++ b/packages/lexicons/scripts/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": "*.ts"
+}

--- a/packages/lexicons/tsconfig.json
+++ b/packages/lexicons/tsconfig.json
@@ -13,5 +13,5 @@
     "skipLibCheck": true
   },
   "include": ["index.ts", "src/**/*"],
-  "exclude": ["node_modules", "dist", "scripts"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
fix #67

This seems to be working but I only checked related codes in type generate script. There might be something I missed.

related upstream change: https://github.com/bluesky-social/atproto/pull/2378