### PR TITLE
chore: introduce editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*]
+end_of_line = lf
+indent_style = space
+max_line_length = 80

--- a/biome.json
+++ b/biome.json
@@ -28,9 +28,7 @@
     }
   },
   "formatter": {
-    "indentStyle": "space",
-    "lineWidth": 80,
-    "lineEnding": "lf"
+    "useEditorconfig": true
   },
   "vcs": {
     "enabled": true,


### PR DESCRIPTION
fix #29

Biome supports external `.editorconfig` so this change won't change the current behavior.

Editors such as VS Code and JetBrains have a Biome plugin, which we can configure to run when saving files. So that could be enough to apply the correct format without `.editorconfig`. But maybe editors can provide better formatting support with `.editorconfig`.