### PR TITLE
ci: setup pkg.pr.new

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,25 @@
+name: Publish any commit with pkg.pr.new
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - uses: pnpm/action-setup@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: pnpm
+
+    - name: Install dependencies
+      run: pnpm install
+
+    - name: Build
+      run: pnpm build
+
+    - run: pnpm dlx pkg-pr-new publish './packages/client' --packageManager=pnpm


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to run pkg.pr.new (https://github.com/stackblitz-labs/pkg.pr.new). This will allow publishing a temporary package under `pkg.pr.new` for each commit before merging any PR for easier testing.