### PR TITLE
chore: suspend auto lexicons update

### DIFF
--- a/.github/workflows/update-lexicons.yml
+++ b/.github/workflows/update-lexicons.yml
@@ -6,8 +6,8 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 3 * * *'
+#  schedule:
+#    - cron: '0 3 * * *'
   workflow_dispatch: {}
   merge_group: {}
 


### PR DESCRIPTION
This will suspend auto lexicon updates by GitHub Actions. A better way would be adopting atcute's latest lexicons.

I don't have enough time working on tsky/nimbus these days (sorry 🙏🏻) and I've been updating only lexicons, but if I understand correctly, `@atcute/bluesky` and other packages now export types for the latest lexicons (ref. https://npmx.dev/package/@atcute/bluesky) since its marjor update around Spring 2025 and we could use them instead of repeating its maintainance and generation.

Our lexicon generator is based on a very old internal generator of atcute and it requires a deep understanding of atproto lexicons to maintain. While we should switch to the atcute lexicons, the migration involves major changes. This branch (https://github.com/tsky-dev/tsky/tree/shuuji3/chore/migrate-atcute-lexicon-packages) was my previous attempt to replace `@tsky/lexicon` with atcute lexicon but it has not been fully tested and gone stale now 🥲 

FYI: @patak-dev 